### PR TITLE
fix/bplist small errors

### DIFF
--- a/lib/parsing/bplist.zig
+++ b/lib/parsing/bplist.zig
@@ -75,7 +75,7 @@ const Parser = struct {
 
     pub fn deinit(self: *Parser) void {
         deinitObjectTable(self.allocator, self.object_table);
-        self.allocator.free(self.offset_table);
+        self.allocator.free(self.object_table);
         self.string_bytes.deinit();
     }
 


### PR DESCRIPTION
- **fix: free object table, not offset table**
  

- **fix: test fixes**
  - use std.testing.allocator
  - allocate enough for utf-16be to pass
  - put top object in object array
  

- **test: create test for successful deinitialization of the parser**
  